### PR TITLE
Add Core ML encoder path

### DIFF
--- a/depthcrafter/pipeline_coreml.py
+++ b/depthcrafter/pipeline_coreml.py
@@ -1,0 +1,60 @@
+from typing import Optional
+
+import numpy as np
+import torch
+
+from .depth_crafter_ppl import DepthCrafterPipeline, _resize_with_antialiasing_safe
+
+
+class Encoder2DCoreML(torch.nn.Module):
+    """Wrapper around a Core ML image encoder."""
+
+    def __init__(self, mlmodel):
+        super().__init__()
+        self.mlmodel = mlmodel
+
+    @classmethod
+    def from_mlpackage(cls, path: str, compute_units=None):
+        import coremltools as ct
+
+        cfg = ct.models.MLModelConfiguration()
+        cfg.compute_units = compute_units or ct.ComputeUnit.CPU_AND_NE
+        mlmodel = ct.models.MLModel(path, configuration=cfg)
+        return cls(mlmodel)
+
+    def forward(self, frames_bchw: torch.Tensor) -> torch.Tensor:
+        x = frames_bchw.detach().cpu().numpy()
+        y = self.mlmodel.predict({"input": x})["output"]
+        return torch.from_numpy(np.array(y))
+
+
+class DepthCrafterCoreMLPipeline(DepthCrafterPipeline):
+    """DepthCrafterPipeline that can offload the 2D image encoder to Core ML."""
+
+    def __init__(self, coreml_encoder: Optional[Encoder2DCoreML] = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.coreml_encoder = coreml_encoder
+
+    @torch.inference_mode()
+    def encode_video(self, video: torch.Tensor, chunk_size: int = 14) -> torch.Tensor:
+        if self.coreml_encoder is None:
+            return super().encode_video(video, chunk_size)
+
+        video_224 = _resize_with_antialiasing_safe(video.float(), (224, 224))
+        video_224 = (video_224 + 1.0) / 2.0
+
+        embeddings = []
+        for i in range(0, video_224.shape[0], chunk_size):
+            tmp = self.feature_extractor(
+                images=video_224[i : i + chunk_size],
+                do_normalize=True,
+                do_center_crop=False,
+                do_resize=False,
+                do_rescale=False,
+                return_tensors="pt",
+            ).pixel_values.to(video.device, dtype=video.dtype)
+            emb = self.coreml_encoder(tmp).to(video.device)
+            embeddings.append(emb)
+
+        embeddings = torch.cat(embeddings, dim=0)
+        return embeddings

--- a/experiments/coreml_poc/convert_coreml_encoder.py
+++ b/experiments/coreml_poc/convert_coreml_encoder.py
@@ -1,0 +1,17 @@
+import torch
+import coremltools as ct
+
+
+def main():
+    exported = torch.export.load("encoder2d.pt2")
+    example = torch.randn(1, 3, 224, 224, dtype=torch.float32)
+    mlmodel = ct.convert(exported, inputs=[ct.TensorType(shape=example.shape)])
+    cfg = ct.models.MLModelConfiguration()
+    cfg.compute_units = ct.ComputeUnit.CPU_AND_NE
+    mlmodel = ct.models.MLModel(mlmodel.get_spec(), configuration=cfg)
+    mlmodel.save("encoder2d.mlpackage")
+    print("Saved encoder2d.mlpackage")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/coreml_poc/export_encoder2d.py
+++ b/experiments/coreml_poc/export_encoder2d.py
@@ -1,0 +1,20 @@
+import sys
+import torch
+from depthcrafter.depth_crafter_ppl import DepthCrafterPipeline
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python export_encoder2d.py <model_id_or_path>")
+        return
+    model_id = sys.argv[1]
+    pipe = DepthCrafterPipeline.from_pretrained(model_id, torch_dtype=torch.float32)
+    encoder = pipe.image_encoder.eval()
+    example = (torch.randn(1, 3, 224, 224, dtype=torch.float32),)
+    exported = torch.export.export(encoder, example)
+    exported.save("encoder2d.pt2")
+    print("Saved encoder2d.pt2")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/coreml_poc/infer_coreml_encoder.py
+++ b/experiments/coreml_poc/infer_coreml_encoder.py
@@ -1,0 +1,18 @@
+import sys
+import torch
+from depthcrafter.pipeline_coreml import Encoder2DCoreML
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python infer_coreml_encoder.py <encoder2d.mlpackage>")
+        return
+    mlpackage = sys.argv[1]
+    encoder = Encoder2DCoreML.from_mlpackage(mlpackage)
+    example = torch.randn(1, 3, 224, 224, dtype=torch.float32)
+    feats = encoder(example)
+    print(feats.shape)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Core ML wrapper and pipeline subclass for offloading the image encoder
- add scripts to export, convert, and test the 2D encoder for Core ML

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a75c38e7ec833291a5ae46695734c1